### PR TITLE
Fixes disappearing tooltips problem

### DIFF
--- a/opentip.js
+++ b/opentip.js
@@ -140,6 +140,9 @@ var Tips = {
 		if (element._opentipAddedTips) {
 			/* TODO: Now it just returns the first found... try to find the correct one. */
 			var tip = this.list.find(function(t) { return (t.triggerElement === element); });
+			if (tip.waitingToShow) {
+			    tip.show();
+			}
 			if (tip.options.showOn == 'creation') tip.show();
 			Opentip.debug('Using an existing opentip');
 			return;


### PR DESCRIPTION
This (kinda) fixes a problem where grouped tooltips with a hideTrigger other than 'target' disappear when rolled over rapidly. Somehow, the waitingToShow property gets stuck to true on these tips and the tooltip never displays again. To fix it, I just check for the symptom, and tell the tip to show if the flag is stuck. While this produces the desired behavior (the tooltip always displays as it should), the real work will be to discover why the flag gets stuck to begin with and unsticking it at the source of the problem. This fix is just a band-aid. :)
