### PR TITLE
EscapeHtml is added to options

### DIFF
--- a/opentip.js
+++ b/opentip.js
@@ -106,7 +106,8 @@ Opentip.styles = {
 		target: null, // null (no target, opentip uses mouse as target)   ||   true (target is the triggerElement)   ||   elementId|element (for another element)
 		targetJoint: null, // POSITION (Ignored if target == null)   ||   null (targetJoint is the opposite of tipJoint)
 		ajax: false, // Ajax options. eg: { url: 'yourUrl.html', options: { ajaxOptions... } } or { options: { ajaxOptions } /* This will use the href of the A element the tooltip is attached to */ }
-		group: null // You can group opentips together. So when a tooltip shows, it looks if there are others in the same group, and hides them.
+		group: null, // You can group opentips together. So when a tooltip shows, it looks if there are others in the same group, and hides them.
+		escapeHtml: false
 	},
 	slick: {
 		className: 'slick',
@@ -336,7 +337,7 @@ var TipClass = Class.create({
 		if (this.options.title) headerContent.push(Builder.node('div', { className: 'title' }, this.options.title));
 
 		content.push(Builder.node('div', { className: 'header' }, headerContent));
-		content.push($(Builder.node('div', { className: 'content' })).update(this.content));
+		content.push($(Builder.node('div', { className: 'content' })).update(this.options.escapeHtml ? this.content.escapeHTML() : this.content ));
 		if (this.options.ajax) { content.push($(Builder.node('div', { className: 'loadingIndication' }, Builder.node('span', 'Loading...')))); }
 		this.tooltipElement = $(Builder.node('div', { className: 'opentip' }, content));
 

--- a/test/index.html
+++ b/test/index.html
@@ -357,6 +357,11 @@
 		$('groupTest').select('button').each(function(button) { button.addTip('Test', { style: 'grouped' }); });
 	</script>
 
+	<br />
+
+	<div class="test" id="testEscapeHtml" onclick="javascript:Tips.add(this, event, '&lt;script&gt;alert(\'Escape html test!!\');</script>', { style: 'standard', stem: true, tipJoint: [ 'left', 'middle' ], targetJoint: [ 'right', 'middle' ], target: true, hideOn: 'click', escapeHtml: true });">
+		Escape html test
+	</div>
 
 
 	<div id="helper" style="background: rgba(255, 0, 0, 0.2);position: absolute;"></div>


### PR DESCRIPTION
It develops as "<" even if it writes like "&lt;" when javascript is written in the attribute of Tag. 
As a result, there is danger from which the script not intended is executed.
EscapeHtml is added to Options, and escapeHTML() is executed at true.
EscapeHtml default is "false" but, "true" is more safe.
