### PR TITLE
Update css/opentip.css

### DIFF
--- a/css/opentip.css
+++ b/css/opentip.css
@@ -129,13 +129,15 @@
 .opentip-container.loading .loading-indicator {
   display: block;
 }
-.opentip-container.style-dark .opentip,
-.opentip-container.style-alert .opentip {
+.opentip-container.style-dark .opentip *,
+.opentip-container.style-alert .opentip * {
   color: #f8f8f8;
   text-shadow: 1px 1px 0px rgba(0,0,0,0.2);
 }
 .opentip-container.style-glass .opentip {
   padding: 15px 25px;
+}
+.opentip-container.style-glass .opentip * {
   color: #317cc5;
   text-shadow: 1px 1px 8px rgba(0,94,153,0.3);
 }


### PR DESCRIPTION
The text color and shadow of the tooltip should be applied on any sub element.
For example, I used it with some HTML content and the h2 tags appear black instead of white with the dark style.
