### PR TITLE
docs: Fix simple typo, funtion -> function

### DIFF
--- a/downloads/opentip-jquery-excanvas.js
+++ b/downloads/opentip-jquery-excanvas.js
@@ -1847,7 +1847,7 @@ if (!document.createElement('canvas').getContext) {
   var Z2 = Z / 2;
 
   /**
-   * This funtion is assigned to the <canvas> elements as element.getContext().
+   * This function is assigned to the <canvas> elements as element.getContext().
    * @this {HTMLElement}
    * @return {CanvasRenderingContext2D_}
    */

--- a/downloads/opentip-native-excanvas.js
+++ b/downloads/opentip-native-excanvas.js
@@ -2034,7 +2034,7 @@ if (!document.createElement('canvas').getContext) {
   var Z2 = Z / 2;
 
   /**
-   * This funtion is assigned to the <canvas> elements as element.getContext().
+   * This function is assigned to the <canvas> elements as element.getContext().
    * @this {HTMLElement}
    * @return {CanvasRenderingContext2D_}
    */

--- a/downloads/opentip-prototype-excanvas.js
+++ b/downloads/opentip-prototype-excanvas.js
@@ -1876,7 +1876,7 @@ if (!document.createElement('canvas').getContext) {
   var Z2 = Z / 2;
 
   /**
-   * This funtion is assigned to the <canvas> elements as element.getContext().
+   * This function is assigned to the <canvas> elements as element.getContext().
    * @this {HTMLElement}
    * @return {CanvasRenderingContext2D_}
    */


### PR DESCRIPTION
There is a small typo in downloads/opentip-jquery-excanvas.js, downloads/opentip-native-excanvas.js, downloads/opentip-prototype-excanvas.js.

Should read `function` rather than `funtion`.

